### PR TITLE
remove traces of `input.cpp`

### DIFF
--- a/tahm/tahm.vcxproj
+++ b/tahm/tahm.vcxproj
@@ -158,7 +158,6 @@
     <ClCompile Include="tahm\audio.cpp" />
     <ClCompile Include="tahm\font.cpp" />
     <ClCompile Include="tahm\graphics.cpp" />
-    <ClCompile Include="tahm\input.cpp" />
     <ClCompile Include="tahm\renderer.cpp" />
     <ClCompile Include="tahm\sound.cpp" />
     <ClCompile Include="tahm\tahm.cpp" />

--- a/tahm/tahm.vcxproj.filters
+++ b/tahm/tahm.vcxproj.filters
@@ -24,9 +24,6 @@
     <ClCompile Include="tahm\graphics.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="tahm\input.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="tahm\renderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
in `tahm.vcxproj` and `tahm.vcxproj.filters` files, `input.cpp` is listed. Cannot compile from Visual Studio.
by removing them, compilation would be fine