### PR TITLE
Linux build with meson working (on Arch Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,20 @@ void update()
 
 <br/>
 
+
+
+---
+
+# Linux
+
+## Pre-requisites
+
+```bash
+# Arch Linux
+sudo pacman -S meson sdl2 sdl2_ttf base-devel
+```
+
+```bash
+chmod +x run.sh
+./run.sh
+```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ void update()
 
 ```bash
 # Arch Linux
-sudo pacman -S meson sdl2 sdl2_ttf base-devel
+sudo pacman -S meson sdl12-compat sdl2_ttf base-devel
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ void update()
 
 ```bash
 # Arch Linux
-sudo pacman -S meson sdl12-compat sdl2_ttf base-devel
+sudo pacman -S meson sdl2 sdl2_ttf base-devel
 ```
 
 ```bash

--- a/meson.build
+++ b/meson.build
@@ -2,9 +2,9 @@ project('tahm', 'cpp',
   version : '0.1.0',
   default_options : [
     'cpp_std=c++23',
-    'warning_level=3', # 3 is the default
-    'buildtype=debug',
-    'optimization=0',
+    'warning_level=3',  # 3 is the default
+    'buildtype=debug',  # debug is the default
+    'optimization=0',   # 0 is the default, 0 is for debug
   ]
 )
 
@@ -33,6 +33,7 @@ src_files = files(
     'tahm/tahm/window.cpp',
 )
 
+# Define the linker arguments
 link_args = [
  
 ]
@@ -46,12 +47,12 @@ dependencies = [
     sdl_ttf_dep,
 ]
 
-# Includes
+# Project includes
 inc_dir = include_directories(
     'tahm/tahm',
 )
 
-# Make the executable
+# Create the executable
 executable('tahm', 
   src_files,
   include_directories: inc_dir,

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,62 @@
+project('tahm', 'cpp',
+  version : '0.1.0',
+  default_options : [
+    'cpp_std=c++23',
+    'warning_level=3', # 3 is the default
+    'buildtype=debug',
+    'optimization=0',
+  ]
+)
+
+c_args = [
+  '-Wall',
+  '-Wextra',
+]
+
+cpp_args = [
+  '-Wno-pedantic',
+  '-Wno-narrowing',
+  '-Wno-missing-field-initializers',
+]
+
+# Define the source files for the project
+src_files = files(
+    'tahm/main.cpp',
+    'tahm/engine.cpp',
+
+    'tahm/tahm/audio.cpp',
+    'tahm/tahm/font.cpp',
+    'tahm/tahm/graphics.cpp',
+    'tahm/tahm/renderer.cpp',
+    'tahm/tahm/sound.cpp',
+    'tahm/tahm/tahm.cpp',
+    'tahm/tahm/window.cpp',
+)
+
+link_args = [
+ 
+]
+
+
+sdl_dep = dependency('sdl2', required: true)
+sdl_ttf_dep = dependency('sdl2_ttf', required: true)
+
+dependencies = [
+    sdl_dep,
+    sdl_ttf_dep,
+]
+
+# Includes
+inc_dir = include_directories(
+    'tahm/tahm',
+)
+
+# Make the executable
+executable('tahm', 
+  src_files,
+  include_directories: inc_dir,
+  dependencies: dependencies,
+  c_args: c_args,
+  cpp_args: cpp_args,
+  link_args: link_args,
+)

--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,10 @@
 set -xe
 
 # Set up the build directory
-meson setup builddir
+meson setup build/linux-x86_64
 
 # build the project
-ninja -C builddir
+ninja -C build/linux-x86_64
 
 # run the project
-./builddir/tahm 
+./build/linux-x86_64/tahm 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# show commands being run
+set -xe
+
+# Set up the build directory
+meson setup builddir
+
+# build the project
+ninja -C builddir
+
+# run the project
+./builddir/tahm 


### PR DESCRIPTION
Hello Tamta!

I created a Linux build, with the Meson build system. 
The (black) game window opens as it should.

Tested on Linux:
Linux 6.10.6-10-MANJARO (Arch)

An Arch Linux user only has to (install dependencies and) enable execution on the file run.sh:
```bash
chmod +x run.sh
```

And then build and run the whole project with:
```bash
./run.sh
```

The depencencies I listed in the README.md are very easy to translate to other Linux distributions.

Wonderful project by the way :)

Best regards,
Victor

