### PR TITLE
FEAT: Add support for the library to run on Ubuntu and Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,28 @@ void update()
 
 <br/>
 
+
+
+---
+
+# Linux
+
+## Pre-requisites
+
+```bash
+# Arch Linux
+sudo pacman -S meson sdl2 sdl2_ttf base-devel
+```
+
+```bash
+# Ubuntu
+sudo apt update
+sudo apt install libsdl2-dev libsdl2-ttf-dev build-essential
+```
+
+## Run
+
+```bash
+chmod +x run.sh
+./run.sh
+```

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,63 @@
+project('tahm', 'cpp',
+  version : '0.1.0',
+  default_options : [
+    'cpp_std=c++20',
+    'warning_level=3',  # 3 is the default
+    'buildtype=debug',  # debug is the default
+    'optimization=0',   # 0 is the default, 0 is for debug
+  ]
+)
+
+c_args = [
+  '-Wall',
+  '-Wextra',
+]
+
+cpp_args = [
+  # '-Wno-pedantic',
+  # '-Wno-narrowing',
+  # '-Wno-missing-field-initializers',
+]
+
+# Define the source files for the project
+src_files = files(
+    'tahm/main.cpp',
+    'tahm/engine.cpp',
+
+    'tahm/tahm/audio.cpp',
+    'tahm/tahm/font.cpp',
+    'tahm/tahm/graphics.cpp',
+    'tahm/tahm/renderer.cpp',
+    'tahm/tahm/sound.cpp',
+    'tahm/tahm/tahm.cpp',
+    'tahm/tahm/window.cpp',
+)
+
+# Define the linker arguments
+link_args = [
+ 
+]
+
+
+sdl_dep = dependency('sdl2', required: true)
+sdl_ttf_dep = dependency('SDL2_ttf', required: true, method: 'pkg-config')
+
+dependencies = [
+    sdl_dep,
+    sdl_ttf_dep,
+]
+
+# Project includes
+inc_dir = include_directories(
+    'tahm/tahm',
+)
+
+# Create the executable
+executable('tahm', 
+  src_files,
+  include_directories: inc_dir,
+  dependencies: dependencies,
+  c_args: c_args,
+  cpp_args: cpp_args,
+  link_args: link_args,
+)

--- a/meson.build
+++ b/meson.build
@@ -14,9 +14,9 @@ c_args = [
 ]
 
 cpp_args = [
-  # '-Wno-pedantic',
-  # '-Wno-narrowing',
-  # '-Wno-missing-field-initializers',
+  '-Wno-pedantic',
+  '-Wno-narrowing',
+  '-Wno-missing-field-initializers',
 ]
 
 # Define the source files for the project

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,8 @@ link_args = [
 
 
 sdl_dep = dependency('sdl2', required: true)
-sdl_ttf_dep = dependency('SDL2_ttf', required: true, method: 'pkg-config')
+# sdl_ttf_dep = dependency('sdl2_ttf', required: true) # for Arch Linux
+sdl_ttf_dep = dependency('SDL2_ttf', required: true, method: 'pkg-config') # for Ubuntu
 
 dependencies = [
     sdl_dep,

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# show commands being run
+set -xe
+
+# Set up the build directory
+meson setup build/linux-x86_64
+
+# build the project
+ninja -C build/linux-x86_64
+
+# run the project
+./build/linux-x86_64/tahm 


### PR DESCRIPTION
Update the README.md to explain the needed packages and how to run the library on Ubuntu and Arch Linux.

Add meson.build file which is used to specify the needed dependencies and build the binary file of the library.
Add a simple run.sh file to run the whole project with one command from the terminal.