### PR TITLE
FIX: Proper Encapsulation

### DIFF
--- a/tahm/engine.cpp
+++ b/tahm/engine.cpp
@@ -32,10 +32,10 @@ int main(int argc, char* argv[])
 		return 0;
 	}
 
-	tahm.start_ptr = start;
-	tahm.input_ptr = keypressed;
-	tahm.update_ptr = update;
-	tahm.draw_ptr = draw;
+	tahm.initializeCallbacks(
+		start, keypressed,
+		update, draw
+	);
 
 	tahm.run();
 

--- a/tahm/tahm/tahm.cpp
+++ b/tahm/tahm/tahm.cpp
@@ -34,6 +34,16 @@ void Tahm::init(void)
 	audio->setupDevice();
 }
 
+void Tahm::initializeCallbacks(
+	void(*start)(), void(*input)(Event),
+	void(*update)(), void(*draw)()
+) {
+    start_ptr = start;
+    input_ptr = input;
+    update_ptr = update;
+    draw_ptr = draw;
+}
+
 Tahm& Tahm::getInstance(void)
 {
 	if (tahm == nullptr) {

--- a/tahm/tahm/tahm.h
+++ b/tahm/tahm/tahm.h
@@ -43,7 +43,7 @@ private:
 	public:
 
 		// initialize a window, pass a reference inside the SDLwindow
-		void init(void);
+		void init(void); // todo: encapsulate
 
 		// should get called in "start". passes a reference to the desired window title, width, and height,
 		// which is later used by void init to initialize a window with the desired parameters
@@ -79,15 +79,15 @@ private:
 		Renderer(Window& window);
 
 		// initialize renderer
-		void init(void);
+		void init(void); // todo: encapsulate
 
 
 		// prepare a default scene to render - blank black screen
 		// called before the "draw" function
-		void prepare(void);
+		void prepare(void); // todo: encapsulate
 
 		// present the rendered scene to the renderer
-		void present(void);
+		void present(void);	// todo: encapsulate
 	};
 
 public:
@@ -179,7 +179,7 @@ public:
 			Sound(const char* path, SDL_AudioSpec* spec);
 			~Sound();
 
-			void linkDevice(SDL_AudioDeviceID& device);
+			void linkDevice(SDL_AudioDeviceID& device); // todo: encapsulate. Needs friend
 
 			void play();
 		};
@@ -188,7 +188,7 @@ public:
 		Audio();
 
 		void setupDevice();
-		SDL_AudioDeviceID device;
+		SDL_AudioDeviceID device;	// todo: encapsulate. Needs friend
 
 		// create a new sound
 		Sound* newSound(const char* path);
@@ -226,15 +226,15 @@ private:
 public:
 	~Tahm();
 
-	void init(void);
+	void init(void); // todo: encapsulate
 
 	void run();
-	void setup();
-	void loop();
-	void handleEvents();
+	void setup();		// todod: encapsulate
+	void loop();		// todo: encapsulate
+	void handleEvents();	// todo: encapsulate
 
 	static Tahm& getInstance();
 
 	// destroy window, renderer, and quit the application
-	void destroy();
+	void destroy();	// todo: encapsulate
 };

--- a/tahm/tahm/tahm.h
+++ b/tahm/tahm/tahm.h
@@ -23,13 +23,22 @@
 
 class Tahm {
 
-private:
-
+private:	// classes
 	// tahm's window. made up of
 	// the SDL window + methods and parameters for it
 	class Window
 	{
-	private:
+	public:  // attributes
+		SDL_Window* SDLwindow;
+
+	public:	// methods
+		// should get called in "start". passes a reference to
+		// the desired window title, width, and height,
+		// which is later used by void init to initialize a 
+		// window with the desired parameters.
+		void create(const char* title, int width, int height);
+
+	private: // attributes
 		const char* title = "Untitled";
 
 		int width = 400;
@@ -37,47 +46,36 @@ private:
 
 		int flags = 0;
 
-	public:
-		SDL_Window* SDLwindow;
-
-	public:
-
+	private: // methods
 		// initialize a window, pass a reference inside the SDLwindow
 		void init(void); // todo: encapsulate
 
-		// should get called in "start". passes a reference to the desired window title, width, and height,
-		// which is later used by void init to initialize a window with the desired parameters
-		void create(const char* title, int width, int height);
-
+		friend class Tahm;
 	};
 
 	class Input
 	{
-
 	public:
-
 		// holds a reference to the keyboard state
 		const Uint8* keyPressed = SDL_GetKeyboardState(NULL);
 	};
 
-
 	// tahm's renderer. made up of
 	// the SDL renderer + methods and parameters for it
-
 	class Renderer
 	{
-	public:
+	public:	// attributes
 		int flags = SDL_RENDERER_ACCELERATED;
 
 		// pointer that points to the engine's window
 		Window* window;
 		SDL_Renderer* SDLrenderer;
 
-	public:
-
+	public: // methods
 		// creates a reference to the game window
 		Renderer(Window& window);
 
+	private: // methods
 		// initialize renderer
 		void init(void); // todo: encapsulate
 
@@ -88,20 +86,20 @@ private:
 
 		// present the rendered scene to the renderer
 		void present(void);	// todo: encapsulate
+
+		friend class Tahm;
 	};
 
-public:
-
+public:	// classes
 	// functions and methods associated with rendering
 	// used by the developer for rendering different objects
 
 	class Graphics
 	{
-	public:
+	public:	// classes
 		class Font
 		{
-		public:
-
+		public: // methods
 			Font();
 
 			// create new font
@@ -109,7 +107,22 @@ public:
 
 		};
 
-	public:
+		// class for drawing shapes or images
+		class Draw
+		{
+		private: // attributes 
+			Renderer* renderer;
+		public:	// methods
+			Draw(Renderer& renderer);
+
+			SDL_Rect rect(int x, int y, int width, int height);
+		};
+
+	public:	// attributes
+		Draw* draw;
+		Font* font;
+
+	public: // methods
 		Graphics(Renderer& renderer);
 		~Graphics();
 
@@ -132,78 +145,57 @@ public:
 		// and the text that should be rendered
 		void printf(const char* alignment, int alignmentWidth, int marginX, int marginY, TTF_Font* font, const char* text);
 
-		// class for drawing shapes or images
-
-		class Draw
-		{
-		private:
-			Renderer* renderer;
-		public:
-			Draw(Renderer& renderer);
-
-			SDL_Rect rect(int x, int y, int width, int height);
-		};
-
-	private:
+	private:	// attributes
 		Renderer* renderer;
 
-	public:
-		Draw* draw;
-		Font* font;
-
 		// current active color
-	private:
 		Color color = { 0, 0, 0 };
+
 	};
 
-
 	// general class for audio management
-
 	class Audio
 	{
-	public:
-
+	public:	// classes
 		// class for creating sound instances
-
 		class Sound
 		{
-		private:
+		private:	// attributes
 			SDL_AudioSpec* spec;
 			Uint8* waveStart;
 			Uint32 waveLength;
 
-
 			SDL_AudioDeviceID* device;
 
-		public:
+		public:	// methods
 			Sound(const char* path, SDL_AudioSpec* spec);
 			~Sound();
 
+			void play();
+		
+		private:
 			void linkDevice(SDL_AudioDeviceID& device); // todo: encapsulate. Needs friend
 
-			void play();
+			friend class Audio;
 		};
 
-	public:
+	public:	// methods
 		Audio();
-
-		void setupDevice();
-		SDL_AudioDeviceID device;	// todo: encapsulate. Needs friend
 
 		// create a new sound
 		Sound* newSound(const char* path);
 
-	private:
+	private:	// attributes
+		SDL_AudioDeviceID device;	// todo: encapsulate. Needs friend
 		SDL_AudioSpec spec;
 
+	private:	// methods
+		void setupDevice();
+
+		friend class Tahm;
 	};
 
-
-private:
-	static Tahm* tahm;
-
-public:
-
+public:	// attributes
 	// instances to all of the nested classes
 	Window* window;
 	Input* input;
@@ -214,26 +206,35 @@ public:
 	// update & render running
 	bool running;
 
-	//callbacks
+public:	// methods
+	static Tahm& getInstance();
+
+	void run();
+
+	void initializeCallbacks(
+		void(*start)(), void(*input)(Event),
+		void(*update)(), void(*draw)()
+	);
+
+	~Tahm();
+
+private:	// attributes
+	static Tahm* tahm;
+
+	// callbacks
 	void(*start_ptr)();
 	void(*input_ptr)(Event);
 	void(*update_ptr)();
 	void(*draw_ptr)();
+	// callbacks shouldn't be allowed to be called from the outside
 
-private:
+private:	// methods
 	Tahm();
-
-public:
-	~Tahm();
-
 	void init(void); // todo: encapsulate
 
-	void run();
 	void setup();		// todod: encapsulate
 	void loop();		// todo: encapsulate
 	void handleEvents();	// todo: encapsulate
-
-	static Tahm& getInstance();
 
 	// destroy window, renderer, and quit the application
 	void destroy();	// todo: encapsulate

--- a/tahm/tahm/tahm.h
+++ b/tahm/tahm/tahm.h
@@ -48,7 +48,7 @@ private:	// classes
 
 	private: // methods
 		// initialize a window, pass a reference inside the SDLwindow
-		void init(void); // todo: encapsulate
+		void init(void); 
 
 		friend class Tahm;
 	};
@@ -77,15 +77,15 @@ private:	// classes
 
 	private: // methods
 		// initialize renderer
-		void init(void); // todo: encapsulate
+		void init(void); 
 
 
 		// prepare a default scene to render - blank black screen
 		// called before the "draw" function
-		void prepare(void); // todo: encapsulate
+		void prepare(void); 
 
 		// present the rendered scene to the renderer
-		void present(void);	// todo: encapsulate
+		void present(void);	
 
 		friend class Tahm;
 	};
@@ -173,7 +173,7 @@ public:	// classes
 			void play();
 		
 		private:
-			void linkDevice(SDL_AudioDeviceID& device); // todo: encapsulate. Needs friend
+			void linkDevice(SDL_AudioDeviceID& device); 
 
 			friend class Audio;
 		};
@@ -185,7 +185,7 @@ public:	// classes
 		Sound* newSound(const char* path);
 
 	private:	// attributes
-		SDL_AudioDeviceID device;	// todo: encapsulate. Needs friend
+		SDL_AudioDeviceID device;	
 		SDL_AudioSpec spec;
 
 	private:	// methods
@@ -229,13 +229,13 @@ private:	// attributes
 
 private:	// methods
 	Tahm();
-	void init(void); // todo: encapsulate
+	void init(void); 
 
-	void setup();		// todod: encapsulate
-	void loop();		// todo: encapsulate
-	void handleEvents();	// todo: encapsulate
+	void setup();		
+	void loop();		
+	void handleEvents();	
 
 	// destroy window, renderer, and quit the application
-	void destroy();	// todo: encapsulate
+	void destroy();	
 	
 };

--- a/tahm/tahm/tahm.h
+++ b/tahm/tahm/tahm.h
@@ -202,9 +202,6 @@ public:	// attributes
 	Graphics* graphics;
 	Audio* audio;
 
-	// update & render running
-	bool running;
-
 public:	// methods
 	static Tahm& getInstance();
 
@@ -226,6 +223,9 @@ private:	// attributes
 	void(*update_ptr)();
 	void(*draw_ptr)();
 	// callbacks shouldn't be allowed to be called from the outside
+
+	// update & render running
+	bool running;
 
 private:	// methods
 	Tahm();

--- a/tahm/tahm/tahm.h
+++ b/tahm/tahm/tahm.h
@@ -22,13 +22,13 @@
 // engine class
 
 class Tahm {
-
+	
 private:	// classes
 	// tahm's window. made up of
 	// the SDL window + methods and parameters for it
 	class Window
 	{
-	public:  // attributes
+	public: // attributes
 		SDL_Window* SDLwindow;
 
 	public:	// methods
@@ -93,7 +93,6 @@ private:	// classes
 public:	// classes
 	// functions and methods associated with rendering
 	// used by the developer for rendering different objects
-
 	class Graphics
 	{
 	public:	// classes
@@ -238,4 +237,5 @@ private:	// methods
 
 	// destroy window, renderer, and quit the application
 	void destroy();	// todo: encapsulate
+	
 };


### PR DESCRIPTION
Properly encapsulate all the attributes and methods in the Tahm class that shouldn't be accessible from outside.
This targets both issues #3 and #7. 

Also, the code in the Tahm class is reorganized to have classes first, then public attributes followed by public methods; private attributes then private methods.

```
Tahm
├── private: classes
│   ├── Window
│   │   └── ...
│   ├── Input
│   │   └── ...
│   ├── Renderer
│   │   └── ...
│   └── Audio
│       ├── public: classes
│       │   └── Sound
│       │       └── ...
│       └── ...
├── public: classes
│   └── Graphics
│       ├── public: classes
│       │   ├── Font
│       │   │   └── ...
│       │   └── Draw
│       │       └── ...
│       └── ...
├── public: attributes
├── public: methods
├── private: attributes
└── private: methods
```